### PR TITLE
Add simple P2P cash iOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ Contributions are welcome! Please open issues and submit pull requests for any i
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+## Running the P2P Cash App
+
+The repository includes a simple command line application located in `p2p_cash_app.py`.
+To start the app run:
+
+```bash
+python p2p_cash_app.py
+```
+
+Follow the prompts to create accounts, deposit funds, send money to other users
+and check balances.
+
+
+## Building the iOS App
+
+A minimal iOS implementation is provided in the `ios_p2p_cash` directory. Open the folder in Xcode and build/run the `P2PCashAppiOSApp` target to launch the SwiftUI interface that performs the same basic operations as the Python example.
+
+Unit tests for the Swift code can be found under `ios_p2p_cashTests` and can be executed with Xcode's testing features.

--- a/ios_p2p_cash/AccountManager.swift
+++ b/ios_p2p_cash/AccountManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+class AccountManager: ObservableObject {
+    enum AccountError: Error, LocalizedError {
+        case accountExists
+        case unknownUser
+        case insufficientFunds
+        case invalidAmount
+
+        var errorDescription: String? {
+            switch self {
+            case .accountExists:
+                return "Account already exists"
+            case .unknownUser:
+                return "User does not exist"
+            case .insufficientFunds:
+                return "Insufficient funds"
+            case .invalidAmount:
+                return "Amount must be positive"
+            }
+        }
+    }
+
+    @Published private(set) var balances: [String: Double] = [:]
+
+    func createAccount(_ userId: String) throws {
+        guard balances[userId] == nil else {
+            throw AccountError.accountExists
+        }
+        balances[userId] = 0
+    }
+
+    func deposit(to userId: String, amount: Double) throws {
+        guard amount >= 0 else { throw AccountError.invalidAmount }
+        if balances[userId] == nil {
+            try createAccount(userId)
+        }
+        balances[userId, default: 0] += amount
+    }
+
+    func send(from senderId: String, to receiverId: String, amount: Double) throws {
+        guard amount > 0 else { throw AccountError.invalidAmount }
+        guard let senderBalance = balances[senderId] else {
+            throw AccountError.unknownUser
+        }
+        guard senderBalance >= amount else {
+            throw AccountError.insufficientFunds
+        }
+        if balances[receiverId] == nil {
+            try createAccount(receiverId)
+        }
+        balances[senderId] = senderBalance - amount
+        balances[receiverId, default: 0] += amount
+    }
+
+    func balance(for userId: String) -> Double {
+        return balances[userId] ?? 0
+    }
+}

--- a/ios_p2p_cash/ContentView.swift
+++ b/ios_p2p_cash/ContentView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var manager = AccountManager()
+
+    @State private var userId = ""
+    @State private var amount = ""
+    @State private var receiver = ""
+    @State private var message = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Create Account")) {
+                    HStack {
+                        TextField("User ID", text: $userId)
+                        Button("Create") {
+                            do {
+                                try manager.createAccount(userId)
+                                message = "Account created"
+                            } catch {
+                                message = error.localizedDescription
+                            }
+                        }
+                    }
+                }
+
+                Section(header: Text("Deposit")) {
+                    TextField("User ID", text: $userId)
+                    TextField("Amount", text: $amount)
+                        .keyboardType(.decimalPad)
+                    Button("Deposit") {
+                        if let amt = Double(amount) {
+                            do {
+                                try manager.deposit(to: userId, amount: amt)
+                                message = "Deposited \(amt) to \(userId)"
+                            } catch {
+                                message = error.localizedDescription
+                            }
+                        }
+                    }
+                }
+
+                Section(header: Text("Send Money")) {
+                    TextField("Sender", text: $userId)
+                    TextField("Receiver", text: $receiver)
+                    TextField("Amount", text: $amount)
+                        .keyboardType(.decimalPad)
+                    Button("Send") {
+                        if let amt = Double(amount) {
+                            do {
+                                try manager.send(from: userId, to: receiver, amount: amt)
+                                message = "Sent \(amt) from \(userId) to \(receiver)"
+                            } catch {
+                                message = error.localizedDescription
+                            }
+                        }
+                    }
+                }
+
+                Section(header: Text("Balance")) {
+                    TextField("User ID", text: $userId)
+                    Button("Check") {
+                        let bal = manager.balance(for: userId)
+                        message = "Balance of \(userId): \(bal)"
+                    }
+                }
+
+                if !message.isEmpty {
+                    Section {
+                        Text(message)
+                            .foregroundColor(.blue)
+                    }
+                }
+            }
+            .navigationTitle("P2P Cash App")
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ios_p2p_cash/P2PCashAppiOSApp.swift
+++ b/ios_p2p_cash/P2PCashAppiOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct P2PCashAppiOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios_p2p_cashTests/AccountManagerTests.swift
+++ b/ios_p2p_cashTests/AccountManagerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import ios_p2p_cash
+
+final class AccountManagerTests: XCTestCase {
+    func testDepositAndSend() throws {
+        let manager = AccountManager()
+        try manager.createAccount("alice")
+        try manager.deposit(to: "alice", amount: 100)
+        try manager.createAccount("bob")
+        try manager.send(from: "alice", to: "bob", amount: 40)
+        XCTAssertEqual(manager.balance(for: "alice"), 60)
+        XCTAssertEqual(manager.balance(for: "bob"), 40)
+    }
+
+    func testInsufficientFunds() throws {
+        let manager = AccountManager()
+        try manager.createAccount("alice")
+        XCTAssertThrowsError(try manager.send(from: "alice", to: "bob", amount: 10))
+    }
+}

--- a/p2p_cash_app.py
+++ b/p2p_cash_app.py
@@ -1,0 +1,77 @@
+class P2PCashApp:
+    """Simple peer-to-peer cash application."""
+
+    def __init__(self):
+        # user balances stored in dictionary
+        self.accounts = {}
+
+    def create_account(self, user_id):
+        if user_id in self.accounts:
+            raise ValueError("Account already exists")
+        self.accounts[user_id] = 0
+
+    def deposit(self, user_id, amount):
+        if amount < 0:
+            raise ValueError("Amount must be positive")
+        if user_id not in self.accounts:
+            self.create_account(user_id)
+        self.accounts[user_id] += amount
+
+    def send(self, sender_id, receiver_id, amount):
+        if amount <= 0:
+            raise ValueError("Amount must be positive")
+        if sender_id not in self.accounts:
+            raise ValueError("Sender does not exist")
+        if self.accounts[sender_id] < amount:
+            raise ValueError("Insufficient funds")
+        if receiver_id not in self.accounts:
+            self.create_account(receiver_id)
+        self.accounts[sender_id] -= amount
+        self.accounts[receiver_id] += amount
+
+    def get_balance(self, user_id):
+        if user_id not in self.accounts:
+            return 0
+        return self.accounts[user_id]
+
+
+def main():
+    app = P2PCashApp()
+
+    while True:
+        cmd = input("Enter command (create, deposit, send, balance, quit): ")
+        if cmd == "quit":
+            break
+        elif cmd == "create":
+            uid = input("User ID: ")
+            try:
+                app.create_account(uid)
+                print(f"Account for {uid} created")
+            except ValueError as e:
+                print("Error:", e)
+        elif cmd == "deposit":
+            uid = input("User ID: ")
+            amount = float(input("Amount: "))
+            try:
+                app.deposit(uid, amount)
+                print(f"Deposited {amount} to {uid}")
+            except ValueError as e:
+                print("Error:", e)
+        elif cmd == "send":
+            sender = input("Sender ID: ")
+            receiver = input("Receiver ID: ")
+            amount = float(input("Amount: "))
+            try:
+                app.send(sender, receiver, amount)
+                print(f"Sent {amount} from {sender} to {receiver}")
+            except ValueError as e:
+                print("Error:", e)
+        elif cmd == "balance":
+            uid = input("User ID: ")
+            print(f"Balance of {uid}: {app.get_balance(uid)}")
+        else:
+            print("Unknown command")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_p2p_cash_app.py
+++ b/test_p2p_cash_app.py
@@ -1,0 +1,27 @@
+import unittest
+from p2p_cash_app import P2PCashApp
+
+
+class TestP2PCashApp(unittest.TestCase):
+    def setUp(self):
+        self.app = P2PCashApp()
+        self.app.create_account('alice')
+        self.app.deposit('alice', 100)
+        self.app.create_account('bob')
+
+    def test_deposit(self):
+        self.app.deposit('bob', 50)
+        self.assertEqual(self.app.get_balance('bob'), 50)
+
+    def test_send(self):
+        self.app.send('alice', 'bob', 30)
+        self.assertEqual(self.app.get_balance('alice'), 70)
+        self.assertEqual(self.app.get_balance('bob'), 30)
+
+    def test_insufficient(self):
+        with self.assertRaises(ValueError):
+            self.app.send('bob', 'alice', 10)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a minimal SwiftUI version of the cash app
- include an AccountManager class and basic UI
- add swift unit tests
- document how to build the iOS version in README

## Testing
- `python3 -m pytest -q`
- `swift test` *(fails: Swift is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840580398d08328ac63f03a0e27ef8f